### PR TITLE
Replace legacy Log4j

### DIFF
--- a/financial-module-system/finance/egov/pom.xml
+++ b/financial-module-system/finance/egov/pom.xml
@@ -225,7 +225,7 @@
         <easymockclassextension-version>3.2</easymockclassextension-version>
         <hamcrest-all-version>1.3</hamcrest-all-version>
         <slf4j-version>1.7.25</slf4j-version>
-        <log4j-version>1.2.17</log4j-version>
+        <log4j-version>2.17.2</log4j-version>
         <google-guava-version>23.2-jre</google-guava-version>
         <google.zxing.version>3.3.0</google.zxing.version>
         <recaptcha.version>0.0.8</recaptcha.version>
@@ -985,8 +985,23 @@
                 <version>${slf4j-version}</version>
             </dependency>
             <dependency>
-                <groupId>log4j</groupId>
-                <artifactId>log4j</artifactId>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-api</artifactId>
+                <version>${log4j-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-core</artifactId>
+                <version>${log4j-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-slf4j-impl</artifactId>
+                <version>${log4j-version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.logging.log4j</groupId>
+                <artifactId>log4j-1.2-api</artifactId>
                 <version>${log4j-version}</version>
             </dependency>
             <!-- LOGGING END -->
@@ -1360,8 +1375,20 @@
             <artifactId>slf4j-nop</artifactId>
         </dependency>
         <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
         </dependency>
         <!-- LOGGING END -->
 


### PR DESCRIPTION
## Summary
- switch parent `egov` pom to Log4j 2
- add compatibility module `log4j-1.2-api`

## Testing
- `mvn -q -DskipTests clean compile` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e766a015c8331a093c298317974ad

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded the logging framework to a newer version for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->