### PR TITLE
Add JUnit 5 dependencies

### DIFF
--- a/financial-module-system/egf-instrument/pom.xml
+++ b/financial-module-system/egf-instrument/pom.xml
@@ -113,6 +113,16 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <repositories>
     <repository>

--- a/financial-module-system/finance-collections-voucher-consumer/pom.xml
+++ b/financial-module-system/finance-collections-voucher-consumer/pom.xml
@@ -70,11 +70,21 @@
 			<optional>true</optional>
 		</dependency>
 
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-test</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter</artifactId>
+                        <scope>test</scope>
+                </dependency>
+                <dependency>
+                        <groupId>org.junit.vintage</groupId>
+                        <artifactId>junit-vintage-engine</artifactId>
+                        <scope>test</scope>
+                </dependency>
 
 		<dependency>
 			<groupId>org.egov.services</groupId>


### PR DESCRIPTION
## Summary
- add JUnit Jupiter and Vintage Engine to egf-instrument test scope
- add JUnit Jupiter and Vintage Engine to finance-collections-voucher-consumer test scope

## Testing
- `mvn -q -DskipTests=false test` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685e7675695483319179c4d4ff69f6cf